### PR TITLE
Add CrewAI Langflow Helm chart

### DIFF
--- a/charts/crewai-langflow/Chart.yaml
+++ b/charts/crewai-langflow/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: crewai-langflow
+description: Helm chart to run Langflow preconfigured for CrewAI
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"

--- a/charts/crewai-langflow/Taskfile.yml
+++ b/charts/crewai-langflow/Taskfile.yml
@@ -1,0 +1,17 @@
+version: 3
+vars:
+  ReleaseName: "crewai-langflow"
+  ReleaseNamespace: "testing-crewai-langflow"
+
+tasks:
+  install:
+    cmds:
+      - helm upgrade --install {{.ReleaseName}} -n {{.ReleaseNamespace}} --create-namespace . --set image.repository=langflowai/langflow --set image.tag=latest --set service.port=7860
+
+  template:
+    cmds:
+      - helm template --dry-run {{.ReleaseName}} -n {{.ReleaseNamespace}} --create-namespace . --set image.repository=langflowai/langflow --set image.tag=latest --set service.port=7860 --debug
+
+  uninstall:
+    cmds:
+      - helm uninstall {{.ReleaseName}} -n {{.ReleaseNamespace}}

--- a/charts/crewai-langflow/templates/NOTES.txt
+++ b/charts/crewai-langflow/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "crewai-langflow.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "crewai-langflow.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "crewai-langflow.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "crewai-langflow.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/crewai-langflow/templates/_helpers.tpl
+++ b/charts/crewai-langflow/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "crewai-langflow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "crewai-langflow.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "crewai-langflow.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "crewai-langflow.labels" -}}
+helm.sh/chart: {{ include "crewai-langflow.chart" . }}
+{{ include "crewai-langflow.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "crewai-langflow.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "crewai-langflow.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "crewai-langflow.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "crewai-langflow.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/crewai-langflow/templates/deployments.yml.tpl
+++ b/charts/crewai-langflow/templates/deployments.yml.tpl
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Release.Name}}
+  namespace: {{.Release.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Release.Name}}
+  template:
+    metadata:
+      labels:
+        app: {{.Release.Name}}
+    spec:
+      containers:
+        - name: langflow
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 7860
+          env:
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: "{{ .value }}"
+            {{- end }}

--- a/charts/crewai-langflow/templates/exports.yaml
+++ b/charts/crewai-langflow/templates/exports.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{.Release.Name}}-exports"
+  namespace: {{.Release.Namespace}}
+type: Opaque
+stringData:
+  URL: https://{{.Values.ingress.host}}

--- a/charts/crewai-langflow/templates/ingress.yml.tpl
+++ b/charts/crewai-langflow/templates/ingress.yml.tpl
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{.Release.Name}}
+  namespace: {{.Release.Namespace}}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    {{- if .Values.ingress.tls.enabled }}
+    cert-manager.io/cluster-issuer: {{ required "a valid cluster issuer must be provided" .Values.ingress.tls.clusterIssuer}}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{.Values.ingress.className}}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{.Release.Name}}
+            port:
+              number: 7860
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.host }}-tls
+{{- end }}

--- a/charts/crewai-langflow/templates/service.yml.tpl
+++ b/charts/crewai-langflow/templates/service.yml.tpl
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Release.Name}}
+  namespace: {{.Release.Namespace}}
+spec:
+  selector:
+    app: {{.Release.Name}}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: 7860
+  type: ClusterIP

--- a/charts/crewai-langflow/values.yaml
+++ b/charts/crewai-langflow/values.yaml
@@ -1,0 +1,41 @@
+image:
+  repository: langflowai/langflow
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 7860
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: 
+    cert-manager.io/cluster-issuer: kloudlite-cert-issuer
+  host: crewai-langflow.machinehack-new.clients.kloudlite.io
+  paths:
+    - path: /
+      pathType: Prefix
+  tls:
+    enabled: true
+    clusterIssuer: "kloudlite-cert-issuer"
+
+replicaCount: 1
+
+resources: {}
+
+env:
+  - name: HOST
+    value: "0.0.0.0"
+  - name: PORT
+    value: "7860"
+  - name: LANGFLOW_HOST
+    value: "0.0.0.0"
+  - name: LANGFLOW_PORT
+    value: "7860"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Summary
- create `crewai-langflow` chart based on existing Langflow example
- provide values for default container and ingress host
- add Taskfile for install/template/uninstall
- include templates for deployment, service, ingress, exports, and notes

## Testing
- `helm lint charts/crewai-langflow` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e12bab9e48325ade0a14352055795